### PR TITLE
Parameter Support

### DIFF
--- a/public/func_Connect-GraphQLAPI.ps1
+++ b/public/func_Connect-GraphQLAPI.ps1
@@ -485,7 +485,7 @@ function Connect-GraphQLAPI {
 
             $powershelldatatypes = @('Boolean','String','Int','Character','Integer','float','double')
 
-            $queries = $queries | where {$_.name -eq 'slaDomains'}
+
             
             foreach ($query in $queries) {
                 $track = $track + 1

--- a/public/func_Connect-GraphQLAPI.ps1
+++ b/public/func_Connect-GraphQLAPI.ps1
@@ -160,75 +160,6 @@ function Connect-GraphQLAPI {
                     $output = " { "
 
                     # Get info about the kind
-                    $type = $typelist | where {$_.name -eq "$kind"}
-
-                    # Check here to see if we have edges and nodes
-                    if ($type.fields.name -contains "edges" -and $type.fields.name -contains "nodes") {
-                        # If both edges and nodes exist, let's just pull down edges
-                        $type.fields = $type.fields | where {$_.name -eq "edges"}
-                    }
-                    
-                    foreach ($field in $type.fields) {
-                        $show = $true
-                        $fieldType = getFieldType $field
-                        # Probably need to add more to list here, adding as I find them
-                        $normalTypeList = ('Int','String','Boolean','ID','Float','Date','Long','DateTime','URL','UUID')
-                        $isNormalVar = ($normalTypeList -contains $fieldType)
-                        
-                        # If the field type is not like an INT or String, then it's probably a custom object,
-                        # so let's recursively call our function on it to get it's embedded fields.
-                        if (-Not ($isNormalVar)) {
-                            if ($currentDepth -lt $global:GraphQLInterfaceConnection.Depth) {
-                                # Yes, we are still under the maximum depth allowed, however, if we are only 1 more away from max
-                                # we need to check to see if this object has any "NORMAL" fields - we can output those if it does
-                                # but if it doesn't, we have don't want to as we would need to go to depth + 1 to get fields
-                                # so if it has normal vars, keep going and call the recursive function again, if not, we need not 
-                                # include this field - which means we need to get rid of the opening and closing " {  } " 
-
-                                $temp = $typelist | where-object {$_.name -eq "$fieldType"} 
-
-                                # If we are only one depth away we need to ensure we peak ahead so we don't have blank objects
-                                #problem is with this statement
-                                if ($global:GraphQLInterfaceConnection.Depth - $currentDepth -eq 1) {
-                                    $scalarFields = $temp.fields.type | where {$_.name -in $normalTypeList}
-                                    if ($null -eq $scalarFields) {
-                                        $show = $false
-                                    }
-                                    else {
-                                        $show = $true
-                                    }
-
-                                }
-                                if ($show -eq $true) {
-                                    $output += " $($field.name) "
-                                    # Need to check here if field is an enum but I can't remember why lol
-                                    if ($temp.kind -ne 'ENUM') {
-                                        $output += getFieldsFromKind $fieldType $kind $currentDepth
-                                    } else {
-                                        Continue
-                                    }
-                                }
-                            }      
-                        } else {
-                            $output += " $($field.name) "
-                        }
-                    }
-                    # Close up and return output
-                    $output += " } "
-                    return  $output
-                } else {
-                   
-                }
-            }
-
-            function getFieldsFromKind {
-                param ($kind, $queryReturnType, $currentDepth)
-                if ($currentDepth -lt $global:GraphQLInterfaceConnection.Depth) {
-                    $currentDepth += 1
-                    # Open up output
-                    $output = " { "
-
-                    # Get info about the kind
                     #$type = $typelist | where {$_.name -eq "$kind"}
                     $type = $typelisthash[$kind]
                     # Check here to see if we have edges and nodes
@@ -406,6 +337,7 @@ function Connect-GraphQLAPI {
                                 }else {
                                     $argString += '$' + $argument.name + ': ' + "$($argument.type.ofType.name)$required "
                                 }
+                                $queryArgs.Add("$($argument.name)","$($argument.type.ofType.name)")
                             } else {
                                 # Let's go deeper - this can probably be ported out to a function and recursion eventually
                                 if ($null -ne $argument.type.ofType.ofType.name) {
@@ -414,13 +346,15 @@ function Connect-GraphQLAPI {
                                     } else {
                                         $argSTring += '$' + $argument.name + ': ' + " $($argument.type.ofType.ofType.name)$required "
                                     }
-                                    
+                                    $queryArgs.Add("$($argument.name)","$($argument.type.ofType.ofType.name)")
                                 } else {
                                     $argSTring += '$' + $argument.name + ': ' + " ISSUE FINDING ARG "
+                                    $queryArgs.Add("$($argument.name)","ISSUEFINDINGARGTYPE")
                                 }
                             }
                         } else {
                             $argString += '$' + $argument.name + ': ' + $argument.type.name + "$required "
+                            $queryArgs.Add("$($argument.name)","$($argument.type.name)")
                         }
                     }
                     $argString += " ) "
@@ -432,7 +366,7 @@ function Connect-GraphQLAPI {
                 } else {
                     $argSTring += "{ objects: $($query.name) "
                 }
-                return $argString
+                return $argString,$queryArgs
             }
 
             # This reference command is used to store the scriptblock of what we want our dynamically-created
@@ -452,15 +386,23 @@ function Connect-GraphQLAPI {
 
                     # Get the query syntax from our CommandInfo
                     $querysyntax = $__CommandInfo[$MyInvocation.MyCommand.Name]['QueryString']
+                    $queryArguments = $__CommandInfo[$MyInvocation.MyCommand.Name]['Arguments']
                     # Here is where specific code for each cmdlet will go!
                     Write-Verbose -Message "I'm the '$($PSCmdlet.MyInvocation.MyCommand.Name)' command!"
                     Write-Verbose -Message "Query Syntax: $querysyntax"
                     if ($PSBoundParameters.ContainsKey('QueryParams')) {
                         $queryparams = $PSBoundParameters['QueryParams']
-                        $response = runDynQuery -QueryString $querysyntax -QueryParams $queryparams
                     } else {
-                        $response = runDynQuery -QueryString $querysyntax
+                        # Build QueryParams from Bound Params
+                        if ($PSBoundParameters.Count -gt 0) {
+                            $queryparams = @{}
+                            foreach ($param in $PSBoundParameters.GetEnumerator()) {
+                                $queryparams.Add("$($param.key)", $($param.value))
+                            }
+                        }
+                        
                     }
+                    $response = runDynQuery -QueryString $querysyntax -QueryParams $queryparams
                     if ($null -ne $response.edges.node) {
                         return $response.edges.node
                     } else {
@@ -476,7 +418,8 @@ function Connect-GraphQLAPI {
                     [scriptblock] $Definition,
                     [ValidateSet('global','script','local')]
                     [string] $Scope = 'global',
-                    [string] $querystring
+                    [string] $querystring,
+                    [hashtable] $queryArguments
                 )
         
                 begin {
@@ -511,6 +454,7 @@ function Connect-GraphQLAPI {
                     $__CommandInfo[$CommandName] = @{
                         Parameters = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
                         QueryString = "$querystring"
+                        Arguments = "$queryArguments"
                     }
                     & $Definition
                     $null = New-Item -Path function: -Name ${Scope}:${CommandName} -Value $ReferenceCommand -Force
@@ -539,9 +483,10 @@ function Connect-GraphQLAPI {
             $totalqueries = ($queries | Measure-Object).count
             $track = 0
 
+            $powershelldatatypes = @('Boolean','String','Int','Character','Integer','float','double')
 
-
-
+            $queries = $queries | where {$_.name -eq 'slaDomains'}
+            
             foreach ($query in $queries) {
                 $track = $track + 1
                 $percentcomplete = ($track/$totalqueries)*100
@@ -559,8 +504,9 @@ function Connect-GraphQLAPI {
                 $querystring = "query $($query.name) "
 
                 # Include arguments
-                $argString = getQueryArgs $query
+                $argString, $queryArguments = getQueryArgs2 $query
                 $queryString += $argString
+                
                 #Write-Host "Done" -foregroundcolor "yellow"
 
                 # Get Query Return Type
@@ -582,10 +528,21 @@ function Connect-GraphQLAPI {
                 
                 # Let's build some cmdlets :)
 
-                BuildCmdlet -CommandName $cmdletname -QueryString $querystring -Definition {
+                BuildCmdlet -CommandName $cmdletname -QueryString $querystring -queryArguments $queryArguments -Definition {
                     parameter hashtable QueryParams -Attributes (
-                        [parameter] @{Mandatory = $false; }
+                        [parameter] @{Mandatory = $true; ParameterSetName="QueryParams";}
                     )
+                    # Loop through queryArguments and add parameters to cmdlet
+                    foreach ($arg in $queryArguments.GetEnumerator() ) { 
+                        
+                        # For now, let's filter out anything that isn't a PS variable type
+                        if ($powershelldatatypes -contains  $($arg.value)) {
+                            parameter $arg.Value $arg.Name -Attributes (
+                                [parameter] @{Mandatory = $false;  ParameterSetName="IndividualParams";}
+                            )
+                        }
+
+                    }
                 }
                 #Write-Host "====================================="
             }

--- a/public/func_Connect-GraphQLAPI.ps1
+++ b/public/func_Connect-GraphQLAPI.ps1
@@ -371,6 +371,70 @@ function Connect-GraphQLAPI {
                 return $argString
             }
 
+            function getQueryArgs2 {
+                param ($query)
+                # initialize argument string
+                $argString = ""
+
+                # initialize empty hashtable to store args
+                $queryArgs = @{}
+
+                $arguments = $query.args
+                
+                if ($arguments) {
+                    $argString += "("
+                    foreach ($argument in $arguments) {
+                        
+                        $list = "false"
+                        # Is it required
+                      
+                        if ($argument.type.kind -eq "NON_NULL") {
+                            $required = "!"
+                        } elseif ($argument.type.kind -eq "LIST" ) {
+                            if ($argument.type.ofType.kind -eq "NON_NULL") {
+                                $required = "!"
+                                $list = "true"
+                            }
+                        } else {
+                            $required=""
+                        }
+                        if ($null -eq $argument.type.name ) {
+                            # We need to find the argument type
+                            if ($null -ne $argument.type.ofType.name) {
+                                if ($list -eq "true") {
+                                    $argString += '$' + $argument.name + ': ' + "[$($argument.type.ofType.name)$required] "
+                                }else {
+                                    $argString += '$' + $argument.name + ': ' + "$($argument.type.ofType.name)$required "
+                                }
+                            } else {
+                                # Let's go deeper - this can probably be ported out to a function and recursion eventually
+                                if ($null -ne $argument.type.ofType.ofType.name) {
+                                    if ($list -eq "true") {
+                                        $argSTring += '$' + $argument.name + ': ' + " [$($argument.type.ofType.ofType.name)$required] "
+                                    } else {
+                                        $argSTring += '$' + $argument.name + ': ' + " $($argument.type.ofType.ofType.name)$required "
+                                    }
+                                    
+                                } else {
+                                    $argSTring += '$' + $argument.name + ': ' + " ISSUE FINDING ARG "
+                                }
+                            }
+                        } else {
+                            $argString += '$' + $argument.name + ': ' + $argument.type.name + "$required "
+                        }
+                    }
+                    $argString += " ) "
+                    $argSTring += "{ objects: $($query.name) ("
+                    foreach ($argument in $arguments) {
+                      $argSTring += $argument.name + ': $' + $argument.name + " "
+                    }
+                    $argSTring += ") "
+                } else {
+                    $argSTring += "{ objects: $($query.name) "
+                }
+                return $argString
+            }
+
             # This reference command is used to store the scriptblock of what we want our dynamically-created
             # cmdlets to do
             $ReferenceCommand = {
@@ -493,10 +557,10 @@ function Connect-GraphQLAPI {
                 
                 # Open up QueryString to hold entire query syntax
                 $querystring = "query $($query.name) "
-                #Write-Host "Getting args " -nonewline
-                $arguments = $query.args
+
+                # Include arguments
                 $argString = getQueryArgs $query
-                $querySTring += $argSTring
+                $queryString += $argString
                 #Write-Host "Done" -foregroundcolor "yellow"
 
                 # Get Query Return Type

--- a/public/func_Connect-GraphQLAPI.ps1
+++ b/public/func_Connect-GraphQLAPI.ps1
@@ -221,7 +221,7 @@ function Connect-GraphQLAPI {
                 }
             }
 
-            function getFieldsFromKind2 {
+            function getFieldsFromKind {
                 param ($kind, $queryReturnType, $currentDepth)
                 if ($currentDepth -lt $global:GraphQLInterfaceConnection.Depth) {
                     $currentDepth += 1
@@ -270,7 +270,7 @@ function Connect-GraphQLAPI {
                                     $output += " $($field.name) "
                                     # Need to check here if field is an enum but I can't remember why lol
                                     if ($temp.kind -ne 'ENUM') {
-                                        $output += getFieldsFromKind2 $fieldType $kind $currentDepth
+                                        $output += getFieldsFromKind $fieldType $kind $currentDepth
                                     } else {
                                         Continue
                                     }
@@ -504,7 +504,7 @@ function Connect-GraphQLAPI {
                 
                 $currentDepth = 0
                 if ($null -ne $returnType) {
-                    $fieldlist = getFieldsFromKind2 $returnType $returnType $currentDepth
+                    $fieldlist = getFieldsFromKind $returnType $returnType $currentDepth
                     $queryString += $fieldlist
                 } else {
                     # Need to figure out to do without a return type

--- a/queries/types.gql
+++ b/queries/types.gql
@@ -2,6 +2,9 @@ query {
   objects: __schema {
      types {
       name
+            enumValues {
+        name
+      }
       ofType {
         name
         ofType{


### PR DESCRIPTION
The Build Cmdlet functions will now support parameters if any arguments are defined within the GQL Query

For instance, Rubrik has arguments on the slaDomains query - when creating the cmdlet an additional parameter set containing those parameters (such as First, Last, etc...) will now be created with the proper names/types.